### PR TITLE
add controls, pending DCO, tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@
 
 [Unreleased]: https://github.com/friki-io/chaostoolkit-kafka
 
+
+## [0.1.2][]
+
+[0.1.2]: https://github.com/friki-io/chaostoolkit-kafka/tree/0.1.2
+
+### Added 
+
+- **Controls**
+  - `get_production_offsets` to use with `produce_messages` action.
+
 [0.1.1]: https://github.com/friki-io/chaostoolkit-kafka/tree/0.1.1
 
 ## [0.1.1][]
 
-[Unreleased]: https://github.com/friki-io/chaostoolkit-kafka
-
-### Fix
+### Fixed
 
 - release github workflows permissions
 

--- a/chaoskafka/controls/get_production_offsets.py
+++ b/chaoskafka/controls/get_production_offsets.py
@@ -1,13 +1,17 @@
-from chaoslib.types import Configuration, \
-    Activity, Run, Secrets
+from chaoslib.types import Configuration, Activity, Run, Secrets
 
 import logging
 
 logger = logging.getLogger("chaostoolkit")
 
-def after_activity_control(context: Activity, state: Run,
-                           configuration: Configuration = None,
-                           secrets: Secrets = None, **kwargs):
+
+def after_activity_control(
+    context: Activity,
+    state: Run,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+    **kwargs,
+):
     # sourcery skip: remove-unnecessary-cast
     """
     This control is to use with the `produce_messages` action, the idea is
@@ -29,5 +33,6 @@ def after_activity_control(context: Activity, state: Run,
     configuration["partition"] = partition
     configuration["earliest"] = int(earliest)
     configuration["num_messages"] = int(num_messages)
-    logger.debug(f"Earliest offset: {earliest}, "
-                 f"Number of messages: {num_messages}")
+    logger.debug(
+        f"Earliest offset: {earliest}, " f"Number of messages: {num_messages}"
+    )

--- a/chaoskafka/controls/get_production_offsets.py
+++ b/chaoskafka/controls/get_production_offsets.py
@@ -1,0 +1,33 @@
+from chaoslib.types import Configuration, \
+    Activity, Run, Secrets
+
+import logging
+
+logger = logging.getLogger("chaostoolkit")
+
+def after_activity_control(context: Activity, state: Run,
+                           configuration: Configuration = None,
+                           secrets: Secrets = None, **kwargs):
+    # sourcery skip: remove-unnecessary-cast
+    """
+    This control is to use with the `produce_messages` action, the idea is
+    to check all the produced messages, identify the earliest and the number
+    of messages to to consume in the rollback section.
+
+    E.g. Output of produce_messages action:
+    '[{'topic': 'orders', 'partition': 1, 'offset': 14},
+    {'topic': 'orders', 'partition': 1, 'offset': 15},
+    {'topic': 'orders', 'partition': 1, 'offset': 16},
+    {'topic': 'orders', 'partition': 1, 'offset': 17},
+    {'topic': 'orders', 'partition': 1, 'offset': 18}]
+    """
+
+    offsets = [m["offset"] for m in state["output"]]
+    partition = state["output"][0]["partition"]
+    earliest = min(offsets)
+    num_messages = len(offsets)
+    configuration["partition"] = partition
+    configuration["earliest"] = int(earliest)
+    configuration["num_messages"] = int(num_messages)
+    logger.debug(f"Earliest offset: {earliest}, "
+                 f"Number of messages: {num_messages}")

--- a/tests/test_controls.py
+++ b/tests/test_controls.py
@@ -1,0 +1,23 @@
+from chaoskafka.controls.get_production_offsets import after_activity_control
+
+
+def test_after_activity_control():
+    state = {
+        "output": [
+            {"topic": "orders", "partition": 1, "offset": 14},
+            {"topic": "orders", "partition": 1, "offset": 15},
+            {"topic": "orders", "partition": 1, "offset": 16},
+            {"topic": "orders", "partition": 1, "offset": 17},
+            {"topic": "orders", "partition": 1, "offset": 18},
+        ]
+    }
+
+    configuration = {}
+
+    after_activity_control(
+        context=None, state=state, configuration=configuration, secrets=None
+    )
+
+    assert configuration["partition"] == 1
+    assert configuration["earliest"] == 14
+    assert configuration["num_messages"] == 5


### PR DESCRIPTION
Hello
This module is add a control to get offsets and number of messages when using produce messages action.
Ex.

```
method:
- type: action
  name: produce corrupt message kafka !! 
  provider:
    type: python
    module: chaoskafka.actions
    func: produce_messages
    arguments:
      bootstrap_servers: ${boostrap_servers}
      topic: ${topic}
      partition: 1
      messages:
        - '{"id": 4054, "user_id": 2, "pokemon": "budew", "country": "Germany", "price": 246.0, "state": "pending", "timestamp": "2024-08-14 05:38:58.922008'
  pauses:
      after: 120
  controls:
    - name: calculate_offset_num_messages
      provider:
        type: python
        module: chaoskafka.controls.get_production_offsets
```

- [x] Create control.
Thanks.
